### PR TITLE
import setup from setuptools to enable bdist_egg

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 
 long_desc = '''Translates JavaScript to Python code. Js2Py is able to translate and execute virtually any JavaScript code.
 


### PR DESCRIPTION
The command bdist_egg is currently not available. This patch will fix that.