### PR TITLE
Compilation plans

### DIFF
--- a/js2py/evaljs.py
+++ b/js2py/evaljs.py
@@ -77,7 +77,7 @@ class EvalJs(object):
         for k, v in six.iteritems(context):
             setattr(self._var, k, v)
 
-    def execute(self, js=None, use_compile_plan=False):
+    def execute(self, js=None, use_compilation_plan=False):
         """executes javascript js in current context
 
         During initial execute() the converted js is cached for re-use. That means next time you
@@ -98,14 +98,14 @@ class EvalJs(object):
         try:
             compiled = cache[hashkey]
         except KeyError:
-            code = translate_js(js, '', use_compile_plan=use_compile_plan)
+            code = translate_js(js, '', use_compilation_plan=use_compilation_plan)
             compiled = cache[hashkey] = compile(code, '<EvalJS snippet>', 'exec')
         exec(compiled, self._context)
 
-    def eval(self, expression, use_compile_plan=False):
+    def eval(self, expression, use_compilation_plan=False):
         """evaluates expression in current context and returns its value"""
         code = 'PyJsEvalResult = eval(%s)'%json.dumps(expression)
-        self.execute(code, use_compile_plan=use_compile_plan)
+        self.execute(code, use_compilation_plan=use_compilation_plan)
         return self['PyJsEvalResult']
 
     def execute_debug(self, js):

--- a/js2py/evaljs.py
+++ b/js2py/evaljs.py
@@ -77,7 +77,7 @@ class EvalJs(object):
         for k, v in six.iteritems(context):
             setattr(self._var, k, v)
 
-    def execute(self, js=None):
+    def execute(self, js=None, use_compile_plan=False):
         """executes javascript js in current context
 
         During initial execute() the converted js is cached for re-use. That means next time you
@@ -98,14 +98,14 @@ class EvalJs(object):
         try:
             compiled = cache[hashkey]
         except KeyError:
-            code = translate_js(js, '')
+            code = translate_js(js, '', use_compile_plan=use_compile_plan)
             compiled = cache[hashkey] = compile(code, '<EvalJS snippet>', 'exec')
         exec(compiled, self._context)
 
-    def eval(self, expression):
+    def eval(self, expression, use_compile_plan=False):
         """evaluates expression in current context and returns its value"""
         code = 'PyJsEvalResult = eval(%s)'%json.dumps(expression)
-        self.execute(code)
+        self.execute(code, use_compile_plan=use_compile_plan)
         return self['PyJsEvalResult']
 
     def execute_debug(self, js):

--- a/js2py/legecy_translators/constants.py
+++ b/js2py/legecy_translators/constants.py
@@ -23,7 +23,7 @@ def _is_cancelled(source, n):
             break
         cancelled = not cancelled
     return cancelled
-    
+
 def _ensure_regexp(source, n): #<- this function has to be improved
     '''returns True if regexp starts at n else returns False
       checks whether it is not a division '''
@@ -33,7 +33,7 @@ def _ensure_regexp(source, n): #<- this function has to be improved
         k+=1
         if n-k<0:
             return True
-        char = source[n-k] 
+        char = source[n-k]
         if char in markers:
             return True
         if char!=' ' and char!='\n':
@@ -67,12 +67,12 @@ def parse_exponent(source, start):
 def remove_constants(source):
     '''Replaces Strings and Regexp literals in the source code with
        identifiers and *removes comments*. Identifier is of the format:
-       
+
        PyJsStringConst(String const number)_ - for Strings
        PyJsRegExpConst(RegExp const number)_ - for RegExps
 
        Returns dict which relates identifier and replaced constant.
-    
+
        Removes single line and multiline comments from JavaScript source code
        Pseudo comments (inside strings) will not be removed.
 
@@ -138,7 +138,7 @@ def remove_constants(source):
                     elif char==']':
                         regexp_class_count = max(regexp_class_count-1, 0)
                     elif  char=='/' and not regexp_class_count:
-                        quiting_regexp = True 
+                        quiting_regexp = True
                 else:
                     if char not in IDENTIFIER_START:
                         inside_regexp[1] = n
@@ -181,21 +181,21 @@ def remove_constants(source):
     count = 0
     constants = {}
     for end, next_start, typ in comments:
-          res += source[start:end]
-          start = next_start
-          if typ==0: # String
-              name = StringName
-          elif typ==1: # comment
-              continue
-          elif typ==2: # regexp
-              name = RegExpName
-          elif typ==3: # number
-              name = NumberName
-          else:
-              raise RuntimeError()
-          res += ' '+name % count+' '
-          constants[name % count] = source[end: next_start]
-          count += 1
+        res += source[start:end]
+        start = next_start
+        if typ==0: # String
+            name = StringName
+        elif typ==1: # comment
+            continue
+        elif typ==2: # regexp
+            name = RegExpName
+        elif typ==3: # number
+            name = NumberName
+        else:
+            raise RuntimeError()
+        res += ' '+name % count+' '
+        constants[name % count] = source[end: next_start]
+        count += 1
     res+=source[start:]
     # remove this stupid white space
     for e in WHITE:
@@ -205,7 +205,7 @@ def remove_constants(source):
         res = res.replace(e, '\n')
     return res.strip(), constants
 
-    
+
 def recover_constants(py_source, replacements): #now has n^2 complexity. improve to n
     '''Converts identifiers representing Js constants to the PyJs constants
     PyJsNumberConst_1_ which has the true value of 5 will be converted to PyJsNumber(5)'''
@@ -257,7 +257,7 @@ def do_escape(source, n):
         n+=2
         end = parse_num(source, n, HEX)
         if end-n < length:
-                raise SyntaxError('Invalid escape sequence!')
+            raise SyntaxError('Invalid escape sequence!')
         #if length==4:
         #    return unichr(int(source[n:n+4], 16)), n+4 # <- this was a very bad way of solving this problem :)
         return source[n-2:n+length], n+length
@@ -289,6 +289,6 @@ def do_escape(source, n):
 if __name__=='__main__':
     test = ('''
     ''')
-            
+
     t, d = remove_constants(test)
     print t, d

--- a/js2py/translators/translating_nodes.py
+++ b/js2py/translators/translating_nodes.py
@@ -110,7 +110,7 @@ def to_key(literal_or_identifier):
             return unicode(k)
 
 def trans(ele, standard=False):
-    """Translates esprima syntax tree to python by delegating to appriopriate translating node"""
+    """Translates esprima syntax tree to python by delegating to appropriate translating node"""
     try:
         node = globals().get(ele['type'])
         if not node:

--- a/js2py/translators/translator.py
+++ b/js2py/translators/translator.py
@@ -2,6 +2,27 @@ from . import pyjsparser
 #from pyesprima import esprima
 from . import translating_nodes
 
+import hashlib
+import re
+
+# the re below is how we'll recognise numeric constants.
+# it finds any 'simple numeric that is not preceded with an alphanumeric character
+# the numeric can be a float (so a dot is found) but
+# it does not recognise notation such as 123e5, 0xFF, infinity or NaN
+CP_NUMERIC_1 = re.compile(r'(?<![a-zA-Z0-9_"\'])([0-9\.]+)')
+CP_NUMERIC_CONSTANT_PLACEHOLDER = '@@NUM_%i_NUM@@'
+CP_NUMERIC_2 = re.compile(CP_NUMERIC_CONSTANT_PLACEHOLDER.replace('%i', r'([0-9\.]+)'))
+
+# the re below is how we'll recognise string constants
+# it finds a ' or ", then reads until the next matching ' or "
+# this re only services simple cases, it can not be used when
+# there are escaped quotes in the expression
+CP_STRING_1 = re.compile(r'(["\'])(.*?)\1') # this is how we'll recognise string constants
+CP_STRING_CONSTANT_PLACEHOLDER = "'@@STR_%i_STR@@'"
+CP_STRING_2 = re.compile(CP_STRING_CONSTANT_PLACEHOLDER.replace('%i', r'(.*?)'))
+
+cache = {}
+
 # This crap is still needed but I removed it for speed reasons. Have to think of better idea
 # import js2py.pyjs, sys
 # # Redefine builtin objects... Do you have a better idea?
@@ -24,15 +45,88 @@ def dbg(x):
     """does nothing, legacy dummy function"""
     return ''
 
-def translate_js(js, HEADER=DEFAULT_HEADER):
+def translate_js(js, HEADER=DEFAULT_HEADER, use_compile_plan=False):
     """js has to be a javascript source code.
        returns equivalent python code."""
+    if use_compile_plan:
+        return translate_js_with_compile_plan(js, HEADER=HEADER)
     parser = pyjsparser.PyJsParser()
     parsed = parser.parse(js) # js to esprima syntax tree
     # Another way of doing that would be with my auto esprima translation but its much slower and causes import problems:
     # parsed = esprima.parse(js).to_dict()
     translating_nodes.clean_stacks()
     return HEADER + translating_nodes.trans(parsed)  # syntax tree to python code
+
+def translate_js_with_compile_plan(js, HEADER=DEFAULT_HEADER):
+    """js has to be a javascript source code.
+       returns equivalent python code.
+
+       compile plans only work with the following restrictions:
+       - only enabled for oneliner expressions
+       - when there are comments in the js code string substitution is disabled
+       - when there nested escaped quotes string substitution is disabled, so
+
+       cacheable:
+       Q1 == 1 && name == 'harry'
+
+       not cacheable:
+       Q1 == 1 && name == 'harry' // some comment
+
+       not cacheable:
+       Q1 == 1 && name == 'o\'Reilly'
+
+       not cacheable:
+       Q1 == 1 && name /* some comment */ == 'o\'Reilly'
+       """
+    if not r'\"' in js and not r"\'" in js and not r'//' in js and not '/*' in js:
+        # since our regex for strings can't understand newlines don't optimize
+        hasliterals = "'" in js or '"' in js
+    else:
+        hasliterals = False
+
+    class match_increaser(object):
+        matchcount = 0
+
+        def __init__(self, mask):
+            self.mask = mask
+            self.matches = []
+
+        def __call__(self, match):
+            self.matchcount += 1
+            self.matches.append(match.group(0))
+            return self.mask%self.matchcount
+
+    match_increaser_num = match_increaser(CP_NUMERIC_CONSTANT_PLACEHOLDER)
+    compile_plan = re.sub(CP_NUMERIC_1, match_increaser_num, js)
+    if hasliterals:
+        match_increaser_str = match_increaser(CP_STRING_CONSTANT_PLACEHOLDER)
+        compile_plan = re.sub(
+            CP_STRING_1, match_increaser_str, compile_plan
+        )
+    compile_plan = re.sub(CP_NUMERIC_2, "'" + CP_NUMERIC_CONSTANT_PLACEHOLDER.replace('%i', r'\1') + "'", compile_plan)
+
+    cp_hash = hashlib.md5(compile_plan).digest()
+    try:
+        python_code = cache[cp_hash]['proto_python_code']
+    except:
+        parser = pyjsparser.PyJsParser()
+        parsed = parser.parse(compile_plan) # js to esprima syntax tree
+        # Another way of doing that would be with my auto esprima translation but its much slower and causes import problems:
+        # parsed = esprima.parse(js).to_dict()
+        translating_nodes.clean_stacks()
+        python_code = translating_nodes.trans(parsed)  # syntax tree to python code
+        cache[cp_hash] = {
+            'compile_plan': compile_plan,
+            'proto_python_code': python_code,
+        }
+    for counter, value in enumerate(match_increaser_num.matches):
+        python_code = python_code.replace("u'" + CP_NUMERIC_CONSTANT_PLACEHOLDER%(counter+1) + "'", value, 1)
+
+    if hasliterals:
+        for counter, value in enumerate(match_increaser_str.matches):
+            python_code = python_code.replace(CP_STRING_CONSTANT_PLACEHOLDER%(counter+1), value, 1)
+
+    return HEADER + python_code
 
 def trasnlate(js, HEADER=DEFAULT_HEADER):
     """js has to be a javascript source code.

--- a/js2py/translators/translator.py
+++ b/js2py/translators/translator.py
@@ -56,7 +56,7 @@ def dbg(x):
 def translate_js(js, HEADER=DEFAULT_HEADER, use_compilation_plan=False):
     """js has to be a javascript source code.
        returns equivalent python code."""
-    if use_compilation_plan:
+    if use_compilation_plan and not '//' in js and not '/*' in js:
         return translate_js_with_compilation_plan(js, HEADER=HEADER)
     parser = pyjsparser.PyJsParser()
     parsed = parser.parse(js) # js to esprima syntax tree

--- a/js2py/translators/translator.py
+++ b/js2py/translators/translator.py
@@ -9,17 +9,25 @@ import re
 # it finds any 'simple numeric that is not preceded with an alphanumeric character
 # the numeric can be a float (so a dot is found) but
 # it does not recognise notation such as 123e5, 0xFF, infinity or NaN
-CP_NUMERIC_1 = re.compile(r'(?<![a-zA-Z0-9_"\'])([0-9\.]+)')
-CP_NUMERIC_CONSTANT_PLACEHOLDER = '@@NUM_%i_NUM@@'
-CP_NUMERIC_2 = re.compile(CP_NUMERIC_CONSTANT_PLACEHOLDER.replace('%i', r'([0-9\.]+)'))
+CP_NUMERIC_RE = re.compile(r'(?<![a-zA-Z0-9_"\'])([0-9\.]+)')
+CP_NUMERIC_PLACEHOLDER = '__PyJsNUM_%i_PyJsNUM__'
+CP_NUMERIC_PLACEHOLDER_REVERSE_RE = re.compile(
+    CP_NUMERIC_PLACEHOLDER.replace('%i', '([0-9\.]+)')
+    )
 
 # the re below is how we'll recognise string constants
 # it finds a ' or ", then reads until the next matching ' or "
 # this re only services simple cases, it can not be used when
 # there are escaped quotes in the expression
-CP_STRING_1 = re.compile(r'(["\'])(.*?)\1') # this is how we'll recognise string constants
-CP_STRING_CONSTANT_PLACEHOLDER = "'@@STR_%i_STR@@'"
-CP_STRING_2 = re.compile(CP_STRING_CONSTANT_PLACEHOLDER.replace('%i', r'(.*?)'))
+
+#CP_STRING_1 = re.compile(r'(["\'])(.*?)\1') # this is how we'll recognise string constants
+
+CP_STRING = '"([^\\\\"]+|\\\\([bfnrtv\'"\\\\]|[0-3]?[0-7]{1,2}|x[0-9a-fA-F]{2}|u[0-9a-fA-F]{4}))*"|\'([^\\\\\']+|\\\\([bfnrtv\'"\\\\]|[0-3]?[0-7]{1,2}|x[0-9a-fA-F]{2}|u[0-9a-fA-F]{4}))*\''
+CP_STRING_RE = re.compile(CP_STRING) # this is how we'll recognise string constants
+CP_STRING_PLACEHOLDER = '__PyJsSTR_%i_PyJsSTR__'
+CP_STRING_PLACEHOLDER_REVERSE_RE = re.compile(
+    CP_STRING_PLACEHOLDER.replace('%i', '([0-9\.]+)')
+    )
 
 cache = {}
 
@@ -45,11 +53,11 @@ def dbg(x):
     """does nothing, legacy dummy function"""
     return ''
 
-def translate_js(js, HEADER=DEFAULT_HEADER, use_compile_plan=False):
+def translate_js(js, HEADER=DEFAULT_HEADER, use_compilation_plan=False):
     """js has to be a javascript source code.
        returns equivalent python code."""
-    if use_compile_plan:
-        return translate_js_with_compile_plan(js, HEADER=HEADER)
+    if use_compilation_plan:
+        return translate_js_with_compilation_plan(js, HEADER=HEADER)
     parser = pyjsparser.PyJsParser()
     parsed = parser.parse(js) # js to esprima syntax tree
     # Another way of doing that would be with my auto esprima translation but its much slower and causes import problems:
@@ -57,7 +65,43 @@ def translate_js(js, HEADER=DEFAULT_HEADER, use_compile_plan=False):
     translating_nodes.clean_stacks()
     return HEADER + translating_nodes.trans(parsed)  # syntax tree to python code
 
-def translate_js_with_compile_plan(js, HEADER=DEFAULT_HEADER):
+class match_unumerator(object):
+    """This class ise used """
+    matchcount = -1
+
+    def __init__(self, placeholder_mask):
+        self.placeholder_mask = placeholder_mask
+        self.matches = []
+
+    def __call__(self, match):
+        self.matchcount += 1
+        self.matches.append(match.group(0))
+        return self.placeholder_mask%self.matchcount
+
+    def __repr__(self):
+        return '\n'.join(self.placeholder_mask%counter + '=' + match for counter, match in enumerate(self.matches))
+
+    def wrap_up(self, output):
+        for counter, value in enumerate(self.matches):
+            output = output.replace("u'" + self.placeholder_mask%(counter) + "'", value, 1)
+        return output
+
+def get_compilation_plan(js):
+    match_increaser_str = match_unumerator(CP_STRING_PLACEHOLDER)
+    compilation_plan = re.sub(
+        CP_STRING, match_increaser_str, js
+    )
+
+    match_increaser_num = match_unumerator(CP_NUMERIC_PLACEHOLDER)
+    compilation_plan = re.sub(CP_NUMERIC_RE, match_increaser_num, compilation_plan)
+    # now put quotes, note that just patching string replaces is somewhat faster than
+    # using another re:
+    compilation_plan = compilation_plan.replace('__PyJsNUM_', '"__PyJsNUM_').replace('_PyJsNUM__', '_PyJsNUM__"')
+    compilation_plan = compilation_plan.replace('__PyJsSTR_', '"__PyJsSTR_').replace('_PyJsSTR__', '_PyJsSTR__"')
+
+    return match_increaser_str, match_increaser_num, compilation_plan
+
+def translate_js_with_compilation_plan(js, HEADER=DEFAULT_HEADER):
     """js has to be a javascript source code.
        returns equivalent python code.
 
@@ -78,53 +122,26 @@ def translate_js_with_compile_plan(js, HEADER=DEFAULT_HEADER):
        not cacheable:
        Q1 == 1 && name /* some comment */ == 'o\'Reilly'
        """
-    if not r'\"' in js and not r"\'" in js and not r'//' in js and not '/*' in js:
-        # since our regex for strings can't understand newlines don't optimize
-        hasliterals = "'" in js or '"' in js
-    else:
-        hasliterals = False
 
-    class match_increaser(object):
-        matchcount = 0
+    match_increaser_str, match_increaser_num, compilation_plan = get_compilation_plan(js)
 
-        def __init__(self, mask):
-            self.mask = mask
-            self.matches = []
-
-        def __call__(self, match):
-            self.matchcount += 1
-            self.matches.append(match.group(0))
-            return self.mask%self.matchcount
-
-    match_increaser_num = match_increaser(CP_NUMERIC_CONSTANT_PLACEHOLDER)
-    compile_plan = re.sub(CP_NUMERIC_1, match_increaser_num, js)
-    if hasliterals:
-        match_increaser_str = match_increaser(CP_STRING_CONSTANT_PLACEHOLDER)
-        compile_plan = re.sub(
-            CP_STRING_1, match_increaser_str, compile_plan
-        )
-    compile_plan = re.sub(CP_NUMERIC_2, "'" + CP_NUMERIC_CONSTANT_PLACEHOLDER.replace('%i', r'\1') + "'", compile_plan)
-
-    cp_hash = hashlib.md5(compile_plan).digest()
+    cp_hash = hashlib.md5(compilation_plan).digest()
     try:
         python_code = cache[cp_hash]['proto_python_code']
     except:
         parser = pyjsparser.PyJsParser()
-        parsed = parser.parse(compile_plan) # js to esprima syntax tree
+        parsed = parser.parse(compilation_plan) # js to esprima syntax tree
         # Another way of doing that would be with my auto esprima translation but its much slower and causes import problems:
         # parsed = esprima.parse(js).to_dict()
         translating_nodes.clean_stacks()
         python_code = translating_nodes.trans(parsed)  # syntax tree to python code
         cache[cp_hash] = {
-            'compile_plan': compile_plan,
+            'compilation_plan': compilation_plan,
             'proto_python_code': python_code,
         }
-    for counter, value in enumerate(match_increaser_num.matches):
-        python_code = python_code.replace("u'" + CP_NUMERIC_CONSTANT_PLACEHOLDER%(counter+1) + "'", value, 1)
 
-    if hasliterals:
-        for counter, value in enumerate(match_increaser_str.matches):
-            python_code = python_code.replace(CP_STRING_CONSTANT_PLACEHOLDER%(counter+1), value, 1)
+    python_code = match_increaser_str.wrap_up(python_code)
+    python_code = match_increaser_num.wrap_up(python_code)
 
     return HEADER + python_code
 

--- a/testCompilationPlan.py
+++ b/testCompilationPlan.py
@@ -1,0 +1,36 @@
+import js2py
+import datetime
+now = datetime.datetime.now
+
+# the line below will
+# - build a 'compilation plan' by substituting strings and constants with placeholders
+# - then build the ast and emit the python code from that compilation plan
+# - then substitute back in the constants
+# This causes some regex overhead, but for js code with similar structure
+# subsequent translate_js calls are 20 times faster
+js2py.translate_js('name == "Robert" && age == 46', use_compilation_plan=True)
+
+# this lines below will re-use the compilation plan already laid out by the
+# statement above
+js2py.translate_js('name == "Guido" && age == 50', use_compilation_plan=True)
+js2py.translate_js('name == "Spam" && age == 25', use_compilation_plan=True)
+
+# now we'll show off the performance gain:
+start = now()
+for cnt in range(10000):
+	js2py.translate_js('name == "Robert" && age == %i'%cnt, use_compilation_plan=False)
+print(('duration without compilation plan %i'%(now() - start).seconds))
+
+start = now()
+for cnt in range(10000):
+	js2py.translate_js('name == "Robert" && age == %i'%cnt, use_compilation_plan=True)
+print(('duration with compilation plan %i'%(now() - start).seconds))
+
+# you can see how a compilation plan works with the lines below:
+from js2py.translators.translator import get_compilation_plan
+expression = "Age==1 && Gender==2 && JobTitle=='Decision maker'"
+strings, numbers, plan = get_compilation_plan(expression)
+print('strings:\n%s'%strings)
+print('numbers:\n%s'%numbers)
+print('plan:\n%s'%plan)
+print(js2py.translate_js(expression))


### PR DESCRIPTION
At times there's a need to evaluate a lot of expressions that have the same structure. For such cases it's possible to avoid ast parsing by creating and re-using a compilation plan.

See testCompilationPlan.js in the repo for example and demonstration.