### PR TITLE
include hyphen in regexp special single chars

### DIFF
--- a/js2py/translators/pyjsparser.py
+++ b/js2py/translators/pyjsparser.py
@@ -22,7 +22,7 @@ from .pyjsparserdata import *
 from .std_nodes import *
 from pprint import pprint
 
-REGEXP_SPECIAL_SINGLE = {'\\', '^', '$', '*', '+', '?', '.', '[', ']', '(', ')', '{', '{', '|'}
+REGEXP_SPECIAL_SINGLE = {'\\', '^', '$', '*', '+', '?', '.', '[', ']', '(', ')', '{', '{', '|', '-'}
 
 
 import six


### PR DESCRIPTION
I ran into troubles using a JavaScript regexp like /[a\-z]/ where the "-" is meant to be literal. Adding "-" to the REGEXP_SPECIAL_SINGLE set fixes this (for me).