### PR TITLE
fix Array.prototype.sort() in python3

### DIFF
--- a/js2py/prototypes/jsarray.py
+++ b/js2py/prototypes/jsarray.py
@@ -2,6 +2,7 @@ import six
 
 if six.PY3:
     xrange = range
+    import functools
 
 def to_arr(this):
     """Returns Python array from Js array"""
@@ -153,15 +154,23 @@ class ArrayPrototype:
     def sort(cmpfn):
         if not this.Class in {'Array', 'Arguments'}:
             return this.to_object() # do nothing
-        arr = [this.get(str(i)) for i in xrange(len(this))]
+        arr = []
+        for i in xrange(len(this)):
+            arr.append(this.get(six.text_type(i)))
+
         if not arr:
             return this
         if not cmpfn.is_callable():
             cmpfn = None
         cmp = lambda a,b: sort_compare(a, b, cmpfn)
-        arr.sort(cmp=cmp)
+        if six.PY3:
+            key = functools.cmp_to_key(cmp)
+            arr.sort(key=key)
+        else:
+            arr.sort(cmp=cmp)
         for i in xrange(len(arr)):
-            this.put(unicode(i), arr[i])
+            this.put(six.text_type(i), arr[i])
+
         return this
 
     def splice(start, deleteCount):


### PR DESCRIPTION
When supplying a custom sort function to `Array.prototype.sort()` js2py tells me "name 'this' is not defined". 

There are several py3/six compatibility errors in `sort(cmpfn)` in `jsarray.py`. Somehow the list comprehension loses the `this` scope which is most hackishly resolved by not using a list comprehension, but there may be a more elegant solution.

Testcase:

```
/*---
info: > Sort should work with custom compare function in python3 too
description: Test custom compare function in python3
---*/

var myComparefn = function(x,y) {
  return x < y ? -1 : (x > y) ? 1 : 0;
};

var x = new Array(2,1,3);
x.sort(myComparefn);

//CHECK#1
if (!(x[0] === 1 && x[1] === 2 && x[2] === 3)) {
  $ERROR('#1: var x = new Array(2,1,3); x.sort(myComparefn); !(x[0] === 1 && x[1] === 2 && x[2] === 3). Actual: ' + (x[0]) + ", " + (x[1]) + ", " + (x[2]));
}
```