### PR TITLE
TypedArray fixes

### DIFF
--- a/js2py/base.py
+++ b/js2py/base.py
@@ -136,10 +136,10 @@ def Js(val, Clamped=False):
         return PyJsString(val, StringPrototype)
     elif isinstance(val, bool):
         return true if val else false
-    elif isinstance(val, float) or isinstance(val, int) or isinstance(val, long) or isinstance(val, (numpy.int8,numpy.uint8,
-                                                                                                     numpy.int16,numpy.uint16,
-                                                                                                     numpy.int32,numpy.uint32,
-                                                                                                     numpy.float32,numpy.float64)):
+    elif isinstance(val, float) or isinstance(val, int) or isinstance(val, long) or (NUMPY_AVAILABLE and isinstance(val, (numpy.int8,numpy.uint8,
+                                                                                                                          numpy.int16,numpy.uint16,
+                                                                                                                          numpy.int32,numpy.uint32,
+                                                                                                                          numpy.float32,numpy.float64))):
         # This is supposed to speed things up. may not be the case
         if val in NUM_BANK:
             return NUM_BANK[val]
@@ -298,7 +298,7 @@ class PyJs(object):
          if not isinstance(prop, basestring):
              prop = prop.to_string().value
          if not isinstance(prop, basestring): raise RuntimeError('Bug')
-         if prop.isdigit():
+         if NUMPY_AVAILABLE and prop.isdigit():
              if isinstance(self.buff,numpy.ndarray):
                  self.update_array()
          cand = self.get_property(prop)
@@ -338,7 +338,7 @@ class PyJs(object):
              raise MakeError('TypeError', 'Undefined and null dont have properties!')
         if not isinstance(prop, basestring):
              prop = prop.to_string().value
-        if prop.isdigit():
+        if NUMPY_AVAILABLE and prop.isdigit():
             if self.Class == 'Int8Array':
                 val = Js(numpy.int8(val.to_number().value))
             elif self.Class == 'Uint8Array':

--- a/js2py/constructors/jsfloat32array.py
+++ b/js2py/constructors/jsfloat32array.py
@@ -22,36 +22,29 @@ def Float32Array():
         temp = Js(numpy.array(list(a.value), dtype=numpy.float32))
         temp.put('length', Js(len(list(a.value))))
         return temp
-    elif isinstance(a, PyJsArray): # object (array)
+    elif isinstance(a, PyJsArray) or isinstance(a,TypedArray) or isinstance(a,PyJsArrayBuffer): # object (Array, TypedArray)
         array = a.to_list()
         array = [(int(item.value) if item.value != None else 0) for item in array]
         temp = Js(numpy.array(array, dtype=numpy.float32))
         temp.put('length', Js(len(array)))
         return temp
-    elif isinstance(a,TypedArray) or isinstance(a,PyJsArrayBuffer): # TypedArray / buffer
+    elif isinstance(a,PyObjectWrapper): # object (ArrayBuffer, etc)
+        if len(a.obj) % 4 != 0:
+            raise MakeError('RangeError', 'Byte length of Float32Array should be a multiple of 4')
         if len(arguments) > 1:
             offset = int(arguments[1].value)
+            if offset % 4 != 0:
+                raise MakeError('RangeError', 'Start offset of Float32Array should be a multiple of 4')
         else:
             offset = 0
-        if len(arguments) == 3:
+        if len(arguments) > 2:
             length = int(arguments[2].value)
         else:
-            length = a.get('length').to_uint32()
-        temp = Js(numpy.frombuffer(a.array, dtype=numpy.float32, count=length, offset=offset))
+            length = int((len(a.obj)/4)-offset)
+        array = numpy.frombuffer(a.obj, dtype=numpy.float32, count=length, offset=offset)
+        temp = Js(array)
         temp.put('length', Js(length))
-        return temp
-
-    elif isinstance(a,PyObjectWrapper): # object (Python object)
-        if len(arguments) > 1:
-            offset = int(arguments[1].value)
-        else:
-            offset = 0
-        if len(arguments) == 3:
-            length = int(arguments[2].value)
-        else:
-            length = len(a.obj)
-        temp = Js(numpy.frombuffer(a.obj, dtype=numpy.float32, count=length, offset=offset))
-        temp.put('length', Js(length))
+        temp.buff = array
         return temp
     temp = Js(numpy.full(0, 0, dtype=numpy.float32))
     temp.put('length', Js(0))

--- a/js2py/constructors/jsfloat32array.py
+++ b/js2py/constructors/jsfloat32array.py
@@ -40,7 +40,7 @@ def Float32Array():
         if len(arguments) > 2:
             length = int(arguments[2].value)
         else:
-            length = int((len(a.obj)/4)-offset)
+            length = int((len(a.obj)-offset)/4)
         array = numpy.frombuffer(a.obj, dtype=numpy.float32, count=length, offset=offset)
         temp = Js(array)
         temp.put('length', Js(length))

--- a/js2py/constructors/jsfloat64array.py
+++ b/js2py/constructors/jsfloat64array.py
@@ -40,7 +40,7 @@ def Float64Array():
         if len(arguments) > 2:
             length = int(arguments[2].value)
         else:
-            length = int((len(a.obj)/8)-offset)
+            length = int((len(a.obj)-offset)/8)
         array = numpy.frombuffer(a.obj, dtype=numpy.float64, count=length, offset=offset)
         temp = Js(array)
         temp.put('length', Js(length))

--- a/js2py/constructors/jsfloat64array.py
+++ b/js2py/constructors/jsfloat64array.py
@@ -22,36 +22,29 @@ def Float64Array():
         temp = Js(numpy.array(list(a.value), dtype=numpy.float64))
         temp.put('length', Js(len(list(a.value))))
         return temp
-    elif isinstance(a, PyJsArray): # object (array)
+    elif isinstance(a, PyJsArray) or isinstance(a,TypedArray) or isinstance(a,PyJsArrayBuffer): # object (Array, TypedArray)
         array = a.to_list()
         array = [(int(item.value) if item.value != None else 0) for item in array]
         temp = Js(numpy.array(array, dtype=numpy.float64))
         temp.put('length', Js(len(array)))
         return temp
-    elif isinstance(a,TypedArray) or isinstance(a,PyJsArrayBuffer): # TypedArray / buffer
+    elif isinstance(a,PyObjectWrapper): # object (ArrayBuffer, etc)
+        if len(a.obj) % 8 != 0:
+            raise MakeError('RangeError', 'Byte length of Float64Array should be a multiple of 8')
         if len(arguments) > 1:
             offset = int(arguments[1].value)
+            if offset % 8 != 0:
+                raise MakeError('RangeError', 'Start offset of Float64Array should be a multiple of 8')
         else:
             offset = 0
-        if len(arguments) == 3:
+        if len(arguments) > 2:
             length = int(arguments[2].value)
         else:
-            length = a.get('length').to_uint32()
-        temp = Js(numpy.frombuffer(a.array, dtype=numpy.float64, count=length, offset=offset))
+            length = int((len(a.obj)/8)-offset)
+        array = numpy.frombuffer(a.obj, dtype=numpy.float64, count=length, offset=offset)
+        temp = Js(array)
         temp.put('length', Js(length))
-        return temp
-
-    elif isinstance(a,PyObjectWrapper): # object (Python object)
-        if len(arguments) > 1:
-            offset = int(arguments[1].value)
-        else:
-            offset = 0
-        if len(arguments) == 3:
-            length = int(arguments[2].value)
-        else:
-            length = len(a.obj)
-        temp = Js(numpy.frombuffer(a.obj, dtype=numpy.float64, count=length, offset=offset))
-        temp.put('length', Js(length))
+        temp.buff = array
         return temp
     temp = Js(numpy.full(0, 0, dtype=numpy.float64))
     temp.put('length', Js(0))

--- a/js2py/constructors/jsint16array.py
+++ b/js2py/constructors/jsint16array.py
@@ -39,7 +39,7 @@ def Int16Array():
         if len(arguments) > 2:
             length = int(arguments[2].value)
         else:
-            length = int((len(a.obj)/2)-offset)
+            length = int((len(a.obj)-offset)/2)
         array = numpy.frombuffer(a.obj, dtype=numpy.int16, count=length, offset=offset)
         temp = Js(array)
         temp.put('length', Js(length))

--- a/js2py/constructors/jsint32array.py
+++ b/js2py/constructors/jsint32array.py
@@ -40,7 +40,7 @@ def Int32Array():
         if len(arguments) > 2:
             length = int(arguments[2].value)
         else:
-            length = int((len(a.obj)/4)-offset)
+            length = int((len(a.obj)-offset)/4)
         array = numpy.frombuffer(a.obj, dtype=numpy.int32, count=length, offset=offset)
         temp = Js(array)
         temp.put('length', Js(length))

--- a/js2py/constructors/jsint8array.py
+++ b/js2py/constructors/jsint8array.py
@@ -21,39 +21,26 @@ def Int8Array():
         temp = Js(numpy.array(list(a.value), dtype=numpy.int8))
         temp.put('length', Js(len(list(a.value))))
         return temp
-    elif isinstance(a, PyJsArray): # object (array)
+    elif isinstance(a, PyJsArray) or isinstance(a,TypedArray) or isinstance(a,PyJsArrayBuffer): # object (Array, TypedArray)
         array = a.to_list()
         array = [(int(item.value) if item.value != None else 0) for item in array]
         temp = Js(numpy.array(array, dtype=numpy.int8))
         temp.put('length', Js(len(array)))
         return temp
-
-    elif isinstance(a,TypedArray) or isinstance(a,PyJsArrayBuffer): # TypedArray / buffer
+    elif isinstance(a,PyObjectWrapper): # object (ArrayBuffer, etc)
         if len(arguments) > 1:
             offset = int(arguments[1].value)
         else:
             offset = 0
-        if len(arguments) == 3:
+        if len(arguments) > 2:
             length = int(arguments[2].value)
         else:
-            length = a.get('length').to_uint32()
-        temp = Js(numpy.frombuffer(a.array, dtype=numpy.int8, count=length, offset=offset))
+            length = int((len(a.obj))-offset)
+        array = numpy.frombuffer(a.obj, dtype=numpy.int8, count=length, offset=offset)
+        temp = Js(array)
         temp.put('length', Js(length))
+        temp.buff = array
         return temp
-
-    elif isinstance(a,PyObjectWrapper): # object (Python object)
-        if len(arguments) > 1:
-            offset = int(arguments[1].value)
-        else:
-            offset = 0
-        if len(arguments) == 3:
-            length = int(arguments[2].value)
-        else:
-            length = len(a.obj)
-        temp = Js(numpy.frombuffer(a.obj, dtype=numpy.int8, count=length, offset=offset))
-        temp.put('length', Js(length))
-        return temp
-
     temp = Js(numpy.full(0, 0, dtype=numpy.int8))
     temp.put('length', Js(0))
     return temp

--- a/js2py/constructors/jsint8array.py
+++ b/js2py/constructors/jsint8array.py
@@ -35,7 +35,7 @@ def Int8Array():
         if len(arguments) > 2:
             length = int(arguments[2].value)
         else:
-            length = int((len(a.obj))-offset)
+            length = int(len(a.obj)-offset)
         array = numpy.frombuffer(a.obj, dtype=numpy.int8, count=length, offset=offset)
         temp = Js(array)
         temp.put('length', Js(length))

--- a/js2py/constructors/jsuint16array.py
+++ b/js2py/constructors/jsuint16array.py
@@ -39,7 +39,7 @@ def Uint16Array():
         if len(arguments) > 2:
             length = int(arguments[2].value)
         else:
-            length = int((len(a.obj)/2)-offset)
+            length = int((len(a.obj)-offset)/2)
         array = numpy.frombuffer(a.obj, dtype=numpy.uint16, count=length, offset=offset)
         temp = Js(array)
         temp.put('length', Js(length))

--- a/js2py/constructors/jsuint16array.py
+++ b/js2py/constructors/jsuint16array.py
@@ -21,36 +21,29 @@ def Uint16Array():
         temp = Js(numpy.array(list(a.value), dtype=numpy.uint16))
         temp.put('length', Js(len(list(a.value))))
         return temp
-    elif isinstance(a, PyJsArray): # object (array)
+    elif isinstance(a, PyJsArray) or isinstance(a,TypedArray) or isinstance(a,PyJsArrayBuffer): # object (Array, TypedArray)
         array = a.to_list()
         array = [(int(item.value) if item.value != None else 0) for item in array]
         temp = Js(numpy.array(array, dtype=numpy.uint16))
         temp.put('length', Js(len(array)))
         return temp
-    elif isinstance(a,TypedArray) or isinstance(a,PyJsArrayBuffer): # TypedArray / buffer
+    elif isinstance(a,PyObjectWrapper): # object (ArrayBuffer, etc)
+        if len(a.obj) % 2 != 0:
+            raise MakeError('RangeError', 'Byte length of Uint16Array should be a multiple of 2')
         if len(arguments) > 1:
             offset = int(arguments[1].value)
+            if offset % 2 != 0:
+                raise MakeError('RangeError', 'Start offset of Uint16Array should be a multiple of 2')
         else:
             offset = 0
-        if len(arguments) == 3:
+        if len(arguments) > 2:
             length = int(arguments[2].value)
         else:
-            length = a.get('length').to_uint32()
-        temp = Js(numpy.frombuffer(a.array, dtype=numpy.uint16, count=length, offset=offset))
+            length = int((len(a.obj)/2)-offset)
+        array = numpy.frombuffer(a.obj, dtype=numpy.uint16, count=length, offset=offset)
+        temp = Js(array)
         temp.put('length', Js(length))
-        return temp
-
-    elif isinstance(a,PyObjectWrapper): # object (Python object)
-        if len(arguments) > 1:
-            offset = int(arguments[1].value)
-        else:
-            offset = 0
-        if len(arguments) == 3:
-            length = int(arguments[2].value)
-        else:
-            length = len(a.obj)
-        temp = Js(numpy.frombuffer(a.obj, dtype=numpy.uint16, count=length, offset=offset))
-        temp.put('length', Js(length))
+        temp.buff = array
         return temp
     temp = Js(numpy.full(0, 0, dtype=numpy.uint16))
     temp.put('length', Js(0))

--- a/js2py/constructors/jsuint32array.py
+++ b/js2py/constructors/jsuint32array.py
@@ -47,7 +47,7 @@ def Uint32Array():
         if len(arguments) > 2:
             length = int(arguments[2].value)
         else:
-            length = int((len(a.obj)/4)-offset)
+            length = int((len(a.obj)-offset)/4)
         temp = Js(numpy.frombuffer(a.obj, dtype=numpy.uint32, count=length, offset=offset))
         temp.put('length', Js(length))
         return temp

--- a/js2py/constructors/jsuint8array.py
+++ b/js2py/constructors/jsuint8array.py
@@ -22,36 +22,25 @@ def Uint8Array():
         temp = Js(numpy.array(list(a.value), dtype=numpy.uint8))
         temp.put('length', Js(len(list(a.value))))
         return temp
-    elif isinstance(a, PyJsArray): # object (array)
+    elif isinstance(a, PyJsArray) or isinstance(a,TypedArray) or isinstance(a,PyJsArrayBuffer): # object (Array, TypedArray)
         array = a.to_list()
         array = [(int(item.value) if item.value != None else 0) for item in array]
         temp = Js(numpy.array(array, dtype=numpy.uint8))
         temp.put('length', Js(len(array)))
         return temp
-    elif isinstance(a,TypedArray) or isinstance(a,PyJsArrayBuffer): # TypedArray / buffer
+    elif isinstance(a,PyObjectWrapper): # object (ArrayBuffer, etc)
         if len(arguments) > 1:
             offset = int(arguments[1].value)
         else:
             offset = 0
-        if len(arguments) == 3:
+        if len(arguments) > 2:
             length = int(arguments[2].value)
         else:
-            length = a.get('length').to_uint32()
-        temp = Js(numpy.frombuffer(a.array, dtype=numpy.uint8, count=length, offset=offset))
+            length = int((len(a.obj))-offset)
+        array = numpy.frombuffer(a.obj, dtype=numpy.uint8, count=length, offset=offset)
+        temp = Js(array)
         temp.put('length', Js(length))
-        return temp
-
-    elif isinstance(a,PyObjectWrapper): # object (Python object)
-        if len(arguments) > 1:
-            offset = int(arguments[1].value)
-        else:
-            offset = 0
-        if len(arguments) == 3:
-            length = int(arguments[2].value)
-        else:
-            length = len(a.obj)
-        temp = Js(numpy.frombuffer(a.obj, dtype=numpy.uint8, count=length, offset=offset))
-        temp.put('length', Js(length))
+        temp.buff = array
         return temp
     temp = Js(numpy.full(0, 0, dtype=numpy.uint8))
     temp.put('length', Js(0))

--- a/js2py/constructors/jsuint8array.py
+++ b/js2py/constructors/jsuint8array.py
@@ -36,7 +36,7 @@ def Uint8Array():
         if len(arguments) > 2:
             length = int(arguments[2].value)
         else:
-            length = int((len(a.obj))-offset)
+            length = int(len(a.obj)-offset)
         array = numpy.frombuffer(a.obj, dtype=numpy.uint8, count=length, offset=offset)
         temp = Js(array)
         temp.put('length', Js(length))

--- a/js2py/constructors/jsuint8clampedarray.py
+++ b/js2py/constructors/jsuint8clampedarray.py
@@ -15,45 +15,34 @@ def Uint8ClampedArray():
         length = a.to_uint32()
         if length!=a.value:
             raise MakeError('RangeError', 'Invalid array length')
-        temp = Js(numpy.full(length, 0, dtype=numpy.uint8))
+        temp = Js(numpy.full(length, 0, dtype=numpy.uint8), Clamped=True)
         temp.put('length', a)
         return temp
     elif isinstance(a, PyJsString): # object (string)
-        temp = Js(numpy.array(list(a.value), dtype=numpy.uint8))
+        temp = Js(numpy.array(list(a.value), dtype=numpy.uint8), Clamped=True)
         temp.put('length', Js(len(list(a.value))))
         return temp
-    elif isinstance(a, PyJsArray): # object (array)
+    elif isinstance(a, PyJsArray) or isinstance(a,TypedArray) or isinstance(a,PyJsArrayBuffer): # object (Array, TypedArray)
         array = a.to_list()
         array = [(int(item.value) if item.value != None else 0) for item in array]
-        temp = Js(numpy.array(array, dtype=numpy.uint8))
+        temp = Js(numpy.array(array, dtype=numpy.uint8), Clamped=True)
         temp.put('length', Js(len(array)))
         return temp
-    elif isinstance(a,TypedArray) or isinstance(a,PyJsArrayBuffer): # TypedArray / buffer
+    elif isinstance(a,PyObjectWrapper): # object (ArrayBuffer, etc)
         if len(arguments) > 1:
             offset = int(arguments[1].value)
         else:
             offset = 0
-        if len(arguments) == 3:
+        if len(arguments) > 2:
             length = int(arguments[2].value)
         else:
-            length = a.get('length').to_uint32()
-        temp = Js(numpy.frombuffer(a.array, dtype=numpy.uint8, count=length, offset=offset))
+            length = int((len(a.obj))-offset)
+        array = numpy.frombuffer(a.obj, dtype=numpy.uint8, count=length, offset=offset)
+        temp = Js(array, Clamped=True)
         temp.put('length', Js(length))
+        temp.buff = array
         return temp
-
-    elif isinstance(a,PyObjectWrapper): # object (Python object)
-        if len(arguments) > 1:
-            offset = int(arguments[1].value)
-        else:
-            offset = 0
-        if len(arguments) == 3:
-            length = int(arguments[2].value)
-        else:
-            length = len(a.obj)
-        temp = Js(numpy.frombuffer(a.obj, dtype=numpy.uint8, count=length, offset=offset))
-        temp.put('length', Js(length))
-        return temp
-    temp = Js(numpy.full(0, 0, dtype=numpy.uint8))
+    temp = Js(numpy.full(0, 0, dtype=numpy.uint8), Clamped=True)
     temp.put('length', Js(0))
     return temp
 

--- a/js2py/constructors/jsuint8clampedarray.py
+++ b/js2py/constructors/jsuint8clampedarray.py
@@ -36,7 +36,7 @@ def Uint8ClampedArray():
         if len(arguments) > 2:
             length = int(arguments[2].value)
         else:
-            length = int((len(a.obj))-offset)
+            length = int(len(a.obj)-offset)
         array = numpy.frombuffer(a.obj, dtype=numpy.uint8, count=length, offset=offset)
         temp = Js(array, Clamped=True)
         temp.put('length', Js(length))


### PR DESCRIPTION
Seems to work better than previous pull request.
```
>>> import js2py
>>> js2py.eval_js('a = new ArrayBuffer(8); b = new Int32Array(a); c = new Int16Array(a); b[0] = 5; c[0]')
5
```
```
>>> a = js2py.eval_js('new Uint8ClampedArray(5)')
>>> a[0] = 258
>>> a[0]
255
```
```
>>> js2py.eval_js('a = new Int32Array([335544318]); a[0]<<6')
-128
>>> js2py.eval_js('a = new Uint16Array([335544318]); a[0]<<6')
4194176
>>> js2py.eval_js('a = new Uint8Array([335544318]); a[0]<<6')
16256
```
```
>>> js2py.eval_js('a = new ArrayBuffer(16); new Uint32Array(a)')
[0, 0, 0, 0]
>>> js2py.eval_js('a = new ArrayBuffer(16); new Uint32Array(a,4)')
[0, 0, 0]
>>> js2py.eval_js('a = new ArrayBuffer(16); new Uint32Array(a,8,1)')
[0]
>>> js2py.eval_js('a = new ArrayBuffer(16); new Uint32Array(a,0,2)')
[0, 0]
```