### PR TITLE
String should not be wrapped by quotes.

### DIFF
--- a/js2py/base.py
+++ b/js2py/base.py
@@ -24,9 +24,9 @@ if six.PY3:
 
 def str_repr(s):
     if six.PY2:
-        return repr(s.encode('utf-8'))
+        return s.encode('utf-8')
     else:
-        return repr(s)
+        return s
 
 def MakeError(name, message):
     """Returns PyJsException with PyJsError inside"""
@@ -907,12 +907,7 @@ class PyJs(object):
         return self.to_string().value
 
     def __repr__(self):
-        if self.Class=='Object':
-            res = []
-            for e in self:
-                res.append(str_repr(e.value)+': '+str_repr(self.get(e)))
-            return '{%s}'%', '.join(res)
-        elif self.Class=='String':
+        if self.Class=='String':
             return str_repr(self.value)
         elif self.Class in ['Array','Int8Array','Uint8Array','Uint8ClampedArray','Int16Array','Uint16Array','Int32Array','Uint32Array','Float32Array','Float64Array']:
             res = []


### PR DESCRIPTION
String should not be wrapped by quotes.
__repr__ of PyJsObject has been overwritten.