### PR TITLE
Add space argument to recursive convert_to_js_type calls

### DIFF
--- a/js2py/internals/func_utils.py
+++ b/js2py/internals/func_utils.py
@@ -35,7 +35,7 @@ def convert_to_js_type(e, space=None):
             raise MakeError('TypeError', 'Actually an internal error, could not convert to js type because space not specified')
         new = {}
         for k,v in e.items():
-            new[to_string(convert_to_js_type(k))] = convert_to_js_type(v)
+            new[to_string(convert_to_js_type(k, space))] = convert_to_js_type(v, space)
         return space.ConstructObject(new)
     else:
         raise MakeError('TypeError', 'Could not convert to js type!')


### PR DESCRIPTION
Partial fix for #113 (`Object.getOwnPropertyDescriptor` still not dealt with)