### PR TITLE
Fix DeprecationWarning: invalid escape sequence

### DIFF
--- a/js2py/translators/translator.py
+++ b/js2py/translators/translator.py
@@ -16,7 +16,7 @@ pyjsparser.parser.ENABLE_PYIMPORT = True
 CP_NUMERIC_RE = re.compile(r'(?<![a-zA-Z0-9_"\'])([0-9\.]+)')
 CP_NUMERIC_PLACEHOLDER = '__PyJsNUM_%i_PyJsNUM__'
 CP_NUMERIC_PLACEHOLDER_REVERSE_RE = re.compile(
-    CP_NUMERIC_PLACEHOLDER.replace('%i', '([0-9\.]+)')
+    CP_NUMERIC_PLACEHOLDER.replace('%i', r'([0-9\.]+)')
     )
 
 # the re below is how we'll recognise string constants
@@ -30,7 +30,7 @@ CP_STRING = '"([^\\\\"]+|\\\\([bfnrtv\'"\\\\]|[0-3]?[0-7]{1,2}|x[0-9a-fA-F]{2}|u
 CP_STRING_RE = re.compile(CP_STRING) # this is how we'll recognise string constants
 CP_STRING_PLACEHOLDER = '__PyJsSTR_%i_PyJsSTR__'
 CP_STRING_PLACEHOLDER_REVERSE_RE = re.compile(
-    CP_STRING_PLACEHOLDER.replace('%i', '([0-9\.]+)')
+    CP_STRING_PLACEHOLDER.replace('%i', r'([0-9\.]+)')
     )
 
 cache = {}

--- a/tests/run.py
+++ b/tests/run.py
@@ -96,7 +96,7 @@ class FestCase:
         print(self.code)
 
     def _parse_test_info(self):
-        self.raw_info = re.search('/\*---(.+)---\*/', self.raw, re.DOTALL).groups()[0].strip()
+        self.raw_info = re.search(r'/\*---(.+)---\*/', self.raw, re.DOTALL).groups()[0].strip()
         category = None
         category_content = None
         for line in self.raw_info.splitlines() + ['END:']:


### PR DESCRIPTION
Fixes Python 3 warnings:
```python
translators/translator.py:19: DeprecationWarning: invalid escape sequence \.
  CP_NUMERIC_PLACEHOLDER.replace('%i', '([0-9\.]+)')
translators/translator.py:33: DeprecationWarning: invalid escape sequence \.
  CP_STRING_PLACEHOLDER.replace('%i', '([0-9\.]+)')
```