### PR TITLE
Prevent self referencing JsObjectWrapper.__repr__

### DIFF
--- a/js2py/base.py
+++ b/js2py/base.py
@@ -1250,7 +1250,7 @@ class JsObjectWrapper(object):
                                  'Uint16Array', 'Int32Array', 'Uint32Array',
                                  'Float32Array', 'Float64Array', 'Arguments'):
             return repr(self.to_list())
-        return repr(self.to_dict())
+        return str([(i[0], type(i[1]).__name__) for i in self.to_dict().items()])
 
     def __len__(self):
         return len(self._obj)

--- a/js2py/host/console.py
+++ b/js2py/host/console.py
@@ -1,14 +1,15 @@
 from ..base import *
 
-
 @Js
 def console():
     pass
-
 
 @Js
 def log():
     print(arguments[0])
 
-
 console.put('log', log)
+console.put('debug', log)
+console.put('info', log)
+console.put('warn', log)
+console.put('error', log)


### PR DESCRIPTION
fix a case of infinite self-call in JsObjectWrapper.__repr__