### PR TITLE
Fix injected local 'arguments' not working in list comprehension in bind.

### DIFF
--- a/js2py/prototypes/jsfunction.py
+++ b/js2py/prototypes/jsfunction.py
@@ -6,8 +6,6 @@ if six.PY3:
     xrange = range
     unicode = str
 
-# todo fix apply and bind
-
 
 class FunctionPrototype:
     def toString():
@@ -41,6 +39,7 @@ class FunctionPrototype:
         return this.call(obj, args)
 
     def bind(thisArg):
+        arguments_ = arguments
         target = this
         if not target.is_callable():
             raise this.MakeError(
@@ -48,5 +47,5 @@ class FunctionPrototype:
         if len(arguments) <= 1:
             args = ()
         else:
-            args = tuple([arguments[e] for e in xrange(1, len(arguments))])
+            args = tuple([arguments_[e] for e in xrange(1, len(arguments_))])
         return this.PyJsBoundFunction(target, thisArg, args)


### PR DESCRIPTION
Not sure why but at least on `Python 3.7.2`, the injected `arguments` hack was causing an unknown reference when used in the list comprehension. Explicitly bringing it into the local scope (copying from `call`) seemed to fix the issue.

Tested with
<details>
  <summary>JS code</summary>

```javascript
function t(x, y) {
  return x + y;
}
var u = t.call(void 0, 11, 12);
console.log('u: ' + u);
var v = t.apply(void 0, [11, 12]);
console.log('v: ' + v);
var w = t.bind(void 0, 11);
console.log('w: ' + w(12));

function s(x, y) {
  return x + y + this.z;
}
var a = s.call({z: 10}, 11, 12);
console.log('a: ' + a);
var b = s.apply({z: 10}, [11, 12]);
console.log('b: ' + b);
var c = s.bind({z: 10}, 11);
console.log('c: ' + c(12));
```
</details>

<details>
<summary>Transpiled python</summary>

```python
from js2py.pyjs import *
# setting scope
var = Scope( JS_BUILTINS )
set_global_object(var)

# Code follows:
var.registers([u'a', u'c', u'b', u's', u'u', u't', u'w', u'v'])
@Js
def PyJsHoisted_s_(x, y, this, arguments, var=var):
    var = Scope({u'y':y, u'x':x, u'this':this, u'arguments':arguments}, var)
    var.registers([u'y', u'x'])
    return ((var.get(u'x')+var.get(u'y'))+var.get(u"this").get(u'z'))
PyJsHoisted_s_.func_name = u's'
var.put(u's', PyJsHoisted_s_)
@Js
def PyJsHoisted_t_(x, y, this, arguments, var=var):
    var = Scope({u'y':y, u'x':x, u'this':this, u'arguments':arguments}, var)
    var.registers([u'y', u'x'])
    return (var.get(u'x')+var.get(u'y'))
PyJsHoisted_t_.func_name = u't'
var.put(u't', PyJsHoisted_t_)
pass
var.put(u'u', var.get(u't').callprop(u'call', PyJsComma(Js(0.0), Js(None)), Js(11.0), Js(12.0)))
var.get(u'console').callprop(u'log', (Js(u'u: ')+var.get(u'u')))
var.put(u'v', var.get(u't').callprop(u'apply', PyJsComma(Js(0.0), Js(None)), Js([Js(11.0), Js(12.0)])))
var.get(u'console').callprop(u'log', (Js(u'v: ')+var.get(u'v')))
var.put(u'w', var.get(u't').callprop(u'bind', PyJsComma(Js(0.0), Js(None)), Js(11.0)))
var.get(u'console').callprop(u'log', (Js(u'w: ')+var.get(u'w')(Js(12.0))))
pass
PyJs_Object_0_ = Js({u'z':Js(10.0)})
var.put(u'a', var.get(u's').callprop(u'call', PyJs_Object_0_, Js(11.0), Js(12.0)))
var.get(u'console').callprop(u'log', (Js(u'a: ')+var.get(u'a')))
PyJs_Object_1_ = Js({u'z':Js(10.0)})
var.put(u'b', var.get(u's').callprop(u'apply', PyJs_Object_1_, Js([Js(11.0), Js(12.0)])))
var.get(u'console').callprop(u'log', (Js(u'b: ')+var.get(u'b')))
PyJs_Object_2_ = Js({u'z':Js(10.0)})
var.put(u'c', var.get(u's').callprop(u'bind', PyJs_Object_2_, Js(11.0)))
var.get(u'console').callprop(u'log', (Js(u'c: ')+var.get(u'c')(Js(12.0))))
pass
```
</details>

<details>
<summary>Output</summary>

```text
'u: 23'
'v: 23'
'w: 23'
'a: 33'
'b: 33'
'c: 33'
```
</details>

Little confused as to why there seems to be a copy of `prototypes` and `constructors` in the `internals` package. Are these diverging or is one copy more important and the other a temporary workspace? Also should this patch be moved there as well?