### PR TITLE
Extend console.log and js object str on py3

### DIFF
--- a/js2py/base.py
+++ b/js2py/base.py
@@ -250,7 +250,7 @@ def is_generic_descriptor(desc):
 
 ##############################################################################
 
-
+@six.python_2_unicode_compatible
 class PyJs(object):
     PRIMITIVES = frozenset(
         ['String', 'Number', 'Boolean', 'Undefined', 'Null'])
@@ -952,7 +952,7 @@ class PyJs(object):
         '''Generally not a constructor, raise an error'''
         raise MakeError('TypeError', '%s is not a constructor' % self.Class)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.to_string().value
 
     def __repr__(self):

--- a/js2py/host/console.py
+++ b/js2py/host/console.py
@@ -6,7 +6,8 @@ def console():
 
 @Js
 def log():
-    print(arguments[0])
+    args = arguments
+    print(*(args[i] for i in args))
 
 console.put('log', log)
 console.put('debug', log)


### PR DESCRIPTION
Another small PR but small PR's get merged quicker :)

This one prints _all_ arguments passed to `console.log` and also makes `__unicode__` work as expected in py3. `repr` still used `__repr__` but `str` uses `__str__` (or `__unicode__` on py2) so when printing objects we get the expected result (strings without quotes).

Also now supports calling `console.log` with no arguments to print a blank line.

```javascript
console.log('test:', 10);
console.log();
```
```python
from js2py.pyjs import *
# setting scope
var = Scope( JS_BUILTINS )
set_global_object(var)

# Code follows:
var.registers([])
var.get(u'console').callprop(u'log', Js(u'test:'), Js(10.0))
var.get(u'console').callprop(u'log')
pass
```