### PR TITLE
Fix print calls to be compatible with py3.

### DIFF
--- a/js2py/internals/speed.py
+++ b/js2py/internals/speed.py
@@ -47,7 +47,7 @@ t = []
 
 Type = None
 try:
-    print timeit(
+    print(timeit(
         """
 
 t.append(4)
@@ -57,6 +57,6 @@ t.pop()
 
 """,
         "from __main__ import X,Y,namedtuple,array,t,add,Type, izip",
-        number=1000000)
+        number=1000000))
 except:
     raise

--- a/js2py/test_internals.py
+++ b/js2py/test_internals.py
@@ -6,4 +6,4 @@ x = r'''
 function g() {var h123 = 11; return [function g1() {return h123}, new Function('return h123')]}
 g()[1]()
 '''
-print seval.eval_js_vm(x)
+print(seval.eval_js_vm(x))


### PR DESCRIPTION
Should clean out the last of the `print` calls and fix #106 and fix #160.

Possibly something to consider is including a `pip install .` call or `python setup.py install` in the travis script to catch issues when byte compiling the project on different versions.