### PR TITLE
Fix injector for Python 3.8+.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: python
 python:
   - "2.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8-dev"
 # command to install dependencies!
 install: "pip install -r requirements.txt && pip install numpy"
 # command to run tests!

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
 dist: xenial
 language: python
 python:
-  - "2.6"
   - "2.7"
-  - "3.3"
-  - "3.4"
   - "3.5"
   - "3.6"
   - "3.7"

--- a/js2py/utils/injector.py
+++ b/js2py/utils/injector.py
@@ -115,7 +115,16 @@ def append_arguments(code_obj, new_locals):
                 code_obj.co_freevars, code_obj.co_cellvars)
 
     # Done modifying codestring - make the code object
-    return types.CodeType(*args)
+    if hasattr(code_obj, "replace"):
+        # Python 3.8+
+        return code_obj.replace(
+            co_argcount=co_argcount + new_locals_len,
+            co_nlocals=code_obj.co_nlocals + new_locals_len,
+            co_code=code,
+            co_names=names,
+            co_varnames=varnames)
+    else:
+        return types.CodeType(*args)
 
 
 def instructions(code_obj):


### PR DESCRIPTION
The arguments to `CodeType` have changed, but a `replace` method was introduced that we can use.

Fixes #175.

Adds Python 3.7 and 3.8 to Travis CI. Have to then remove support for unsupported Python versions (see https://devguide.python.org/#status-of-python-branches). 