### PR TITLE
Found BUG of translate_file and fixed

### DIFF
--- a/js2py/evaljs.py
+++ b/js2py/evaljs.py
@@ -53,7 +53,7 @@ def write_file_contents(path_or_file, contents):
     if hasattr(path_or_file, 'write'):
         path_or_file.write(contents)
     else:
-        with open(path_as_local(path_or_file), 'w') as f:
+        with codecs.open(path_as_local(path_or_file), "w", "utf-8") as f:
             f.write(contents)
 
 


### PR DESCRIPTION
Function translate_file uses function write_file_contents. However, function write_file_contents doesn't write Python code while using UTF-8 to encode. It will cause problems after translate JS file with special strings ( e.g., Chinese) to Python file. Error will be raised when importing objects from the Python file.
Just like function get_file_contents, used codecs.open to fix the problem.