### PR TITLE
Fix print functions and a python2 only import

### DIFF
--- a/js2py/internals/speed.py
+++ b/js2py/internals/speed.py
@@ -1,7 +1,14 @@
+from __future__ import print_function
+
 from timeit import timeit
 from collections import namedtuple
 from array import array
-from itertools import izip
+try:
+    #python 2 code
+    from itertools import izip as zip
+except ImportError:
+    pass
+
 from collections import deque
 
 
@@ -47,7 +54,7 @@ t = []
 
 Type = None
 try:
-    print timeit(
+    print(timeit(
         """
 
 t.append(4)
@@ -56,7 +63,7 @@ t.pop()
 
 
 """,
-        "from __main__ import X,Y,namedtuple,array,t,add,Type, izip",
-        number=1000000)
+        "from __main__ import X,Y,namedtuple,array,t,add,Type, zip",
+        number=1000000))
 except:
     raise

--- a/js2py/legecy_translators/constants.py
+++ b/js2py/legecy_translators/constants.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from string import ascii_lowercase, digits
 ##################################
 StringName = u'PyJsConstantString%d_'
@@ -305,4 +306,4 @@ if __name__ == '__main__':
     ''')
 
     t, d = remove_constants(test)
-    print t, d
+    print(t, d)

--- a/js2py/legecy_translators/exps.py
+++ b/js2py/legecy_translators/exps.py
@@ -16,6 +16,8 @@ If case of parsing errors it must return a pos of error.
 NOTES:
 Strings and other literals are not present so each = means assignment
 """
+from __future__ import print_function
+
 from utils import *
 from jsparser import *
 
@@ -80,4 +82,4 @@ def bass_translator(s):
 
 
 if __name__ == '__main__':
-    print bass_translator('3.ddsd = 40')
+    print(bass_translator('3.ddsd = 40'))

--- a/js2py/legecy_translators/flow.py
+++ b/js2py/legecy_translators/flow.py
@@ -9,6 +9,8 @@ FOR 123
 FOR iter
 CONTINUE, BREAK, RETURN, LABEL, THROW, TRY, SWITCH
 """
+from __future__ import print_function
+
 from utils import *
 from jsparser import *
 from nodevisitor import exp_translator
@@ -477,4 +479,4 @@ def translate_flow(source):
 if __name__ == '__main__':
     #print do_dowhile('do {} while(k+f)', 0)[0]
     #print 'e: "%s"'%do_expression('++(c?g:h);   mj', 0)[0]
-    print translate_flow('a; yimport test')[0]
+    print(translate_flow('a; yimport test')[0])

--- a/js2py/legecy_translators/functions.py
+++ b/js2py/legecy_translators/functions.py
@@ -1,4 +1,6 @@
 """This module removes JS functions from source code"""
+from __future__ import print_function
+
 from jsparser import *
 from utils import *
 
@@ -94,5 +96,5 @@ def remove_functions(source, all_inline=False):
 
 
 if __name__ == '__main__':
-    print remove_functions(
-        '5+5 function n  (functiona ,functionaj) {dsd  s, dsdd}')
+    print(remove_functions(
+        '5+5 function n  (functiona ,functionaj) {dsd  s, dsdd}'))

--- a/js2py/legecy_translators/jsparser.py
+++ b/js2py/legecy_translators/jsparser.py
@@ -45,6 +45,7 @@ TODO
 
 
 """
+from __future__ import print_function
 
 from utils import *
 
@@ -64,7 +65,7 @@ OP_METHODS = {
 
 def dbg(source):
     try:
-        with open('C:\Users\Piotrek\Desktop\dbg.py', 'w') as f:
+        with open(r'C:\Users\Piotrek\Desktop\dbg.py', 'w') as f:
             f.write(source)
     except:
         pass
@@ -77,13 +78,13 @@ def indent(lines, ind=4):
 def inject_before_lval(source, lval, code):
     if source.count(lval) > 1:
         dbg(source)
-        print
-        print lval
+        print()
+        print(lval)
         raise RuntimeError('To many lvals (%s)' % lval)
     elif not source.count(lval):
         dbg(source)
-        print
-        print lval
+        print()
+        print(lval)
         assert lval not in source
         raise RuntimeError('No lval found "%s"' % lval)
     end = source.index(lval)

--- a/js2py/legecy_translators/nodevisitor.py
+++ b/js2py/legecy_translators/nodevisitor.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from jsparser import *
 from utils import *
 import re
@@ -557,6 +559,6 @@ if __name__ == '__main__':
     #print 'Here',  trans('(eee   )  .   ii  [  PyJsMarker   ]  [   jkj  ]  (  j  ,   j  )  .
     #    jiji   (h  ,  ji  ,  i)(non  )(  )()()()')
     for e in xrange(3):
-        print exp_translator('jk = kk.ik++')
+        print(exp_translator('jk = kk.ik++'))
     #First line translated with PyJs:  PyJsStrictEq(PyJsAdd((Js(100)*Js(50)),Js(30)), Js("5030")), yay!
-    print exp_translator('delete a.f')
+    print(exp_translator('delete a.f'))

--- a/js2py/legecy_translators/objects.py
+++ b/js2py/legecy_translators/objects.py
@@ -1,6 +1,8 @@
 """ This module removes all objects/arrays from JS source code and replace them with LVALS.
 Also it has  s function translating removed object/array to python code.
 Use this module just after removing constants. Later move on to removing functions"""
+from __future__ import print_function
+
 OBJECT_LVAL = 'PyJsLvalObject%d_'
 ARRAY_LVAL = 'PyJsLvalArray%d_'
 from utils import *
@@ -180,7 +182,7 @@ def translate_object(obj, lval, obj_count=1, arr_count=1):
             try:
                 key, value = spl
             except:  #len(spl)> 2
-                print 'Unusual case ' + repr(e)
+                print('Unusual case ' + repr(e))
                 key = spl[0]
                 value = ':'.join(spl[1:])
             key = key.strip()
@@ -293,8 +295,8 @@ if __name__ == '__main__':
 
     #print remove_objects(test)
     #print list(bracket_split(' {}'))
-    print
-    print remove_arrays(
+    print()
+    print(remove_arrays(
         'typeof a&&!db.test(a)&&!ib[(bb.exec(a)||["",""], [][[5][5]])[1].toLowerCase()])'
-    )
-    print is_object('', ')')
+    ))
+    print(is_object('', ')'))

--- a/js2py/legecy_translators/translator.py
+++ b/js2py/legecy_translators/translator.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from flow import translate_flow
 from constants import remove_constants, recover_constants
 from objects import remove_objects, remove_arrays, translate_object, translate_array, set_func_translator
@@ -148,4 +150,4 @@ if __name__ == '__main__':
     #res = translate_js(jq)
     res = translate_js(t)
     dbg(SANDBOX % indent(res))
-    print 'Done'
+    print('Done')


### PR DESCRIPTION
This PR superseeds #166 

The original PR only fixed the call of a print function in one file (one imported during install).
This PR fixes all issues found by running pythons compileall on the source:
```python3 -m compileall .```

Fix #106 
Fix #160 