### PR TITLE
Mark release 0.68

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ More examples at: https://github.com/PiotrDabkowski/Js2Py
 # twine upload dist/*
 setup(
     name='Js2Py',
-    version='0.67',
+    version='0.68',
 
     packages=['js2py', 'js2py.utils', 'js2py.prototypes', 'js2py.translators',
               'js2py.constructors', 'js2py.host', 'js2py.es6', 'js2py.internals',


### PR DESCRIPTION
Since the package has some trouble with python3 installs, a new release where that is fixed is more than welcome.

Cheers.