### PR TITLE
Exception class - attribute message Python3

### DIFF
--- a/js2py/base.py
+++ b/js2py/base.py
@@ -126,7 +126,7 @@ def HJs(val):
             except Exception as e:
                 message = 'your Python function failed!  '
                 try:
-                    message += e.message
+                    message += str(e)
                 except:
                     pass
                 raise MakeError('Error', message)
@@ -1304,7 +1304,7 @@ class PyObjectWrapper(PyJs):
         except Exception as e:
             message = 'your Python function failed!  '
             try:
-                message += e.message
+                message += str(e)
             except:
                 pass
             raise MakeError('Error', message)


### PR DESCRIPTION
fix error msg from python function beacuase python3+ does not support  e.message , just supports str(e) and also python2+ too

fix #197 