### PR TITLE
Fix Date.UTC,  Workaround datetime.datetime.utcfromtimestamp limitation

### DIFF
--- a/js2py/constructors/jsdate.py
+++ b/js2py/constructors/jsdate.py
@@ -75,11 +75,12 @@ class PyJsDate(PyJs):
 
     # todo fix this problematic datetime part
     def to_local_dt(self):
-        return datetime.datetime.utcfromtimestamp(
-            UTCToLocal(self.value) // 1000)
+        return datetime.datetime(1970, 1, 1) + datetime.timedelta(
+            seconds=UTCToLocal(self.value) // 1000)
 
     def to_utc_dt(self):
-        return datetime.datetime.utcfromtimestamp(self.value // 1000)
+        return datetime.datetime(1970, 1, 1) + datetime.timedelta(
+            seconds=self.value // 1000)
 
     def local_strftime(self, pattern):
         if self.value is NaN:

--- a/js2py/constructors/jsdate.py
+++ b/js2py/constructors/jsdate.py
@@ -32,8 +32,7 @@ def UTC(year, month, date, hours, minutes, seconds, ms):  # todo complete this
     mili = args[6].to_number() if l > 6 else Js(0)
     if not y.is_nan() and 0 <= y.value <= 99:
         y = y + Js(1900)
-    t = TimeClip(MakeDate(MakeDay(y, m, dt), MakeTime(h, mi, sec, mili)))
-    return PyJsDate(t, prototype=DatePrototype)
+    return TimeClip(MakeDate(MakeDay(y, m, dt), MakeTime(h, mi, sec, mili)))
 
 
 @Js

--- a/js2py/internals/constructors/jsdate.py
+++ b/js2py/internals/constructors/jsdate.py
@@ -75,11 +75,12 @@ class PyJsDate(PyJs):
 
     # todo fix this problematic datetime part
     def to_local_dt(self):
-        return datetime.datetime.utcfromtimestamp(
-            UTCToLocal(self.value) // 1000)
+        return datetime.datetime(1970, 1, 1) + datetime.timedelta(
+            seconds=UTCToLocal(self.value) // 1000)
 
     def to_utc_dt(self):
-        return datetime.datetime.utcfromtimestamp(self.value // 1000)
+        return datetime.datetime(1970, 1, 1) + datetime.timedelta(
+            seconds=self.value // 1000)
 
     def local_strftime(self, pattern):
         if self.value is NaN:

--- a/js2py/internals/constructors/jsdate.py
+++ b/js2py/internals/constructors/jsdate.py
@@ -32,8 +32,7 @@ def UTC(year, month, date, hours, minutes, seconds, ms):  # todo complete this
     mili = args[6].to_number() if l > 6 else Js(0)
     if not y.is_nan() and 0 <= y.value <= 99:
         y = y + Js(1900)
-    t = TimeClip(MakeDate(MakeDay(y, m, dt), MakeTime(h, mi, sec, mili)))
-    return PyJsDate(t, prototype=DatePrototype)
+    return TimeClip(MakeDate(MakeDay(y, m, dt), MakeTime(h, mi, sec, mili)))
 
 
 @Js


### PR DESCRIPTION
 Removed the Python2 workaround