### PR TITLE
[WIN] Workaround utcfromtimestamp in DaylightSavingTA

### DIFF
--- a/js2py/constructors/time_helpers.py
+++ b/js2py/constructors/time_helpers.py
@@ -36,8 +36,8 @@ def DaylightSavingTA(t):
         return t
     try:
         return int(
-            LOCAL_ZONE.dst(datetime.datetime.utcfromtimestamp(
-                t // 1000)).seconds) * 1000
+            LOCAL_ZONE.dst(datetime.datetime(1970, 1, 1) + datetime.timedelta(
+                seconds=t // 1000)).seconds) * 1000
     except:
         warnings.warn(
             'Invalid datetime date, assumed DST time, may be inaccurate...',

--- a/js2py/internals/base.py
+++ b/js2py/internals/base.py
@@ -602,11 +602,12 @@ class PyJsDate(PyJs):
 
     # todo fix this problematic datetime part
     def to_local_dt(self):
-        return datetime.datetime.utcfromtimestamp(
-            self.UTCToLocal(self.value) // 1000)
+        return datetime.datetime(1970, 1, 1) + datetime.timedelta(
+            seconds=self.UTCToLocal(self.value) // 1000)
 
     def to_utc_dt(self):
-        return datetime.datetime.utcfromtimestamp(self.value // 1000)
+        return datetime.datetime(1970, 1, 1) + datetime.timedelta(
+            seconds=self.value // 1000)
 
     def local_strftime(self, pattern):
         if self.value is NaN:

--- a/js2py/internals/constructors/time_helpers.py
+++ b/js2py/internals/constructors/time_helpers.py
@@ -38,8 +38,8 @@ def DaylightSavingTA(t):
         return t
     try:
         return int(
-            LOCAL_ZONE.dst(datetime.datetime.utcfromtimestamp(
-                t // 1000)).seconds) * 1000
+            LOCAL_ZONE.dst(datetime.datetime(1970, 1, 1) + datetime.timedelta(
+                seconds=t // 1000)).seconds) * 1000
     except:
         warnings.warn(
             'Invalid datetime date, assumed DST time, may be inaccurate...',


### PR DESCRIPTION
This was found in issue #215 reproducible just by loading ssf.js.
```
Traceback (most recent call last):
  File "test.py", line 28, in <module>
    context.execute(js)
  File "C:\Python38\Js2Py-master\js2py\evaljs.py", line 199, in execute
    exec (compiled, self._context)
  File "<EvalJS snippet>", line 2174, in <module>
  File "C:\Python38\Js2Py-master\js2py\base.py", line 949, in __call__
    return self.call(self.GlobalObject, args)
  File "C:\Python38\Js2Py-master\js2py\base.py", line 1464, in call
    return Js(self.code(*args))
  File "<EvalJS snippet>", line 1541, in PyJs_make_ssf_0_
  File "C:\Python38\Js2Py-master\js2py\constructors\jsdate.py", line 149, in date_constructor
    return date_constructor2(*args)
  File "C:\Python38\Js2Py-master\js2py\constructors\jsdate.py", line 181, in date_constructor2
    LocalToUTC(MakeDate(MakeDay(y, m, dt), MakeTime(h, mi, sec, mili))))
  File "C:\Python38\Js2Py-master\js2py\constructors\time_helpers.py", line 54, in LocalToUTC
    return t - LocalTZA - DaylightSavingTA(t - LocalTZA)
  File "C:\Python38\Js2Py-master\js2py\constructors\time_helpers.py", line 39, in DaylightSavingTA
    LOCAL_ZONE.dst(datetime.datetime.utcfromtimestamp(
OSError: [Errno 22] Invalid argument
```
After hitting this issue twice, I searched the code and changed the final occurrence in /internals/base.py.