### PR TITLE
Adds basic support for JS input date formats

### DIFF
--- a/js2py/constructors/jsdate.py
+++ b/js2py/constructors/jsdate.py
@@ -118,13 +118,24 @@ class PyJsDate(PyJs):
 
 
 def parse_date(py_string):  # todo support all date string formats
-    supported_formats = (
-        "%Y-%m-%dT%H:%M:%S.%fZ",
-        "%Y-%m-%dT%H:%M:%SZ",
+    date_formats = (
         "%Y-%m-%d",
         "%m/%d/%Y",
         "%b %d %Y",
     )
+    # Supports these hour formats and with or hour.
+    hour_formats = (
+        "T%H:%M:%S.%f",
+        "T%H:%M:%S",
+    ) + ('',)
+    # Supports with or without Z indicator.
+    z_formats = ("Z",) + ('',)
+    supported_formats = [
+        d + t + z
+        for d in date_formats
+        for t in hour_formats
+        for z in z_formats
+    ]
     for date_format in supported_formats:
         try:
             dt = datetime.datetime.strptime(py_string, date_format)

--- a/js2py/constructors/jsdate.py
+++ b/js2py/constructors/jsdate.py
@@ -118,21 +118,29 @@ class PyJsDate(PyJs):
 
 
 def parse_date(py_string):  # todo support all date string formats
-    try:
+    supported_formats = (
+        "%Y-%m-%dT%H:%M:%S.%fZ",
+        "%Y-%m-%dT%H:%M:%SZ",
+        "%Y-%m-%d",
+        "%m/%d/%Y",
+        "%b %d %Y",
+    )
+    for date_format in supported_formats:
         try:
-            dt = datetime.datetime.strptime(py_string, "%Y-%m-%dT%H:%M:%S.%fZ")
-        except:
-            dt = datetime.datetime.strptime(py_string, "%Y-%m-%dT%H:%M:%SZ")
-        return MakeDate(
-            MakeDay(Js(dt.year), Js(dt.month - 1), Js(dt.day)),
-            MakeTime(
-                Js(dt.hour), Js(dt.minute), Js(dt.second),
-                Js(dt.microsecond // 1000)))
-    except:
-        raise MakeError(
-            'TypeError',
-            'Could not parse date %s - unsupported date format. Currently only supported format is RFC3339 utc. Sorry!'
-            % py_string)
+            dt = datetime.datetime.strptime(py_string, date_format)
+        except ValueError:
+            continue
+        else:
+            return MakeDate(
+                MakeDay(Js(dt.year), Js(dt.month - 1), Js(dt.day)),
+                MakeTime(
+                    Js(dt.hour), Js(dt.minute), Js(dt.second),
+                    Js(dt.microsecond // 1000)))
+
+    raise MakeError(
+        'TypeError',
+        'Could not parse date %s - unsupported date format. Currently only supported formats are RFC3339 utc, ISO Date, Short Date, and Long Date. Sorry!'
+        % py_string)
 
 
 def date_constructor(*args):


### PR DESCRIPTION

### Rationale

I'm working on a project where I have a large JS codebase that runs on V8. It would be very problematic to transform the code to support RFC3339 date format.

With these simple changes Js2Py, would support three very natural date input formats used in the JavaScript world.

### Other approaches

There is the dateutil module that is very powerful and can be plugged in and support many date(time) formats, however, I didn't want to add more dependencies to the project.

In any case, I think this is a good start and it's something that doesn't seem to break compatibility, and at the same time it's easy to maintain.


### TESTS

- New type of date format:
```python
>>> js2py.eval_js("""console.log(new Date('01/01/2010'))""")
'Thu Dec 31 2009 19:00:00 GMT-0500 (EST)'
```


- A bad date format:
```python
>>> js2py.eval_js("""console.log(new Date('x'))""")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/serpulga/src/Js2Py/js2py/evaljs.py", line 115, in eval_js
    return e.eval(js)
  File "/Users/serpulga/src/Js2Py/js2py/evaljs.py", line 204, in eval
    self.execute(code, use_compilation_plan=use_compilation_plan)
  File "/Users/serpulga/src/Js2Py/js2py/evaljs.py", line 199, in execute
    exec (compiled, self._context)
  File "<EvalJS snippet>", line 2, in <module>
  File "/Users/serpulga/src/Js2Py/js2py/base.py", line 949, in __call__
    return self.call(self.GlobalObject, args)
  File "/Users/serpulga/src/Js2Py/js2py/base.py", line 1464, in call
    return Js(self.code(*args))
  File "/Users/serpulga/src/Js2Py/js2py/host/jseval.py", line 45, in Eval
    executor(py_code)
  File "/Users/serpulga/src/Js2Py/js2py/host/jseval.py", line 51, in executor
    exec (code, globals())
  File "<string>", line 2, in <module>
  File "/Users/serpulga/src/Js2Py/js2py/constructors/jsdate.py", line 150, in date_constructor
    return date_constructor1(args[0])
  File "/Users/serpulga/src/Js2Py/js2py/constructors/jsdate.py", line 162, in date_constructor1
    v = parse_date(v.value)
  File "/Users/serpulga/src/Js2Py/js2py/constructors/jsdate.py", line 143, in parse_date
    % py_string)
js2py.internals.simplex.JsException: TypeError: Could not parse date x - unsupported date format. Currently only supported formats are RFC3339 utc, ISO Date, Short Date, and Long Date. Sorry!
```