### PR TITLE
setup.cfg: description-file -> description_file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-description-file = README.md
+description_file = README.md
 
 [yapf]
 based_on_style = pep8


### PR DESCRIPTION
future releases of setuptools will not support "description-file"

'''/usr/lib/python3.9/site-packages/setuptools/dist.py:642:
UserWarning: Usage of dash-separated 'description-file'
will not be supported in future versions. Please use the
underscore name 'description_file' instead'''
warning discovered on setuptools, version 56.0.0

Signed-off-by: Maciej Barć <xgqt@riseup.net>