### PR TITLE
Fix syntax warning in opcodes.py, will error in 3.9+ afaik.

### DIFF
--- a/js2py/internals/opcodes.py
+++ b/js2py/internals/opcodes.py
@@ -798,7 +798,7 @@ OP_CODES = {}
 g = ''
 for g in globals():
     try:
-        if not issubclass(globals()[g], OP_CODE) or g is 'OP_CODE':
+        if not issubclass(globals()[g], OP_CODE) or g is OP_CODE:
             continue
     except:
         continue


### PR DESCRIPTION
fixes warning:
```
...site-packages/js2py/internals/opcodes.py:801: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if not issubclass(globals()[g], OP_CODE) or g is 'OP_CODE':
```

I assume this was meant to include the OP_CODE class