### PR TITLE
Fix String.prototype.replace with `$&` replacement text

### DIFF
--- a/js2py/internals/prototypes/jsstring.py
+++ b/js2py/internals/prototypes/jsstring.py
@@ -22,6 +22,11 @@ def replacement_template(rep, source, span, npar):
                 res += '$'
                 n += 2
                 continue
+            elif rep[n + 1] == '&':
+                # replace with matched string
+                res += source[span[0]:span[1]]
+                n += 2
+                continue
             elif rep[n + 1] == '`':
                 # replace with string that is BEFORE match
                 res += source[:span[0]]

--- a/js2py/prototypes/jsstring.py
+++ b/js2py/prototypes/jsstring.py
@@ -17,6 +17,11 @@ def replacement_template(rep, source, span, npar):
                 res += '$'
                 n += 2
                 continue
+            elif rep[n + 1] == '&':
+                # replace with matched string
+                res += source[span[0]:span[1]]
+                n += 2
+                continue
             elif rep[n + 1] == '`':
                 # replace with string that is BEFORE match
                 res += source[:span[0]]

--- a/tests/run.py
+++ b/tests/run.py
@@ -45,7 +45,7 @@ def terminate_thread(thread):
 
     :param thread: a threading.Thread instance
     """
-    if not thread.isAlive():
+    if not thread.is_alive():
         return
 
     exc = ctypes.py_object(SystemExit)


### PR DESCRIPTION
Thanks for an amazing JS VM/translator! I really appreciate the work you've done to make this so functional.

This fixes #260. These tests now pass on both the translator and the VM:

- String/prototype/replace 15.5.4.11_A2_T3
- String/prototype/replace 15.5.4.11_A2_T8

**Note**: when running the tests, `run.py` looked for a file named `node_failed.txt`. I used an empty file to allow the tests to run; should this be checked into the repo?