### PR TITLE
fix bug when variable name equals Js

### DIFF
--- a/js2py/translators/friendly_nodes.py
+++ b/js2py/translators/friendly_nodes.py
@@ -49,6 +49,8 @@ def get_break_label(label):
 
 
 def is_valid_py_name(name):
+    if name == 'Js':
+        return False
     try:
         compile(name + ' =  11', 'a', 'exec')
     except:


### PR DESCRIPTION
To reproduce

eval_js('(function(Js){1}(5))')