### PR TITLE
Winfix for node_import 

### DIFF
--- a/js2py/host/console.py
+++ b/js2py/host/console.py
@@ -6,7 +6,7 @@ def console():
 
 @Js
 def log():
-    print(*arguments.to_list())
+    print(" ".join(repr(element) for element in arguments.to_list()))
 
 console.put('log', log)
 console.put('debug', log)

--- a/simple_test.py
+++ b/simple_test.py
@@ -18,7 +18,6 @@ if (i !== 10 || j !== 0) {
   throw Error("i: " + i + " j: " + j)
 }
 """
-print(js2py.translate_js(continue_labels_test))
 js2py.eval_js(continue_labels_test)
 
 break_labels_test = """


### PR DESCRIPTION
Recently users reported errors on windows machines regarding the error:
"AssertionError: Could not link required node_modules"
Even with the @alex-pancho fix on it on 2018, idk why it happened again in 2021. Theres the node_import file that I`m using and the solution worked fine.
Please review this :)