### PR TITLE
[WIN] Fix node module support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,9 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-# disabled windows due node packages issues
-#        os: [ubuntu-latest, macos-latest, windows-latest]
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [ '2.x', '3.x', '3.5', '3.6', '3.7', '3.8', '3.9', 'pypy-2.7', 'pypy-3.6', 'pypy-3.7' ]
         exclude:
           - os: windows-latest

--- a/js2py/node_import.py
+++ b/js2py/node_import.py
@@ -21,8 +21,8 @@ def _init():
         'node -v', shell=True, cwd=DIRNAME
     ) == 0, 'You must have node installed! run: brew install node'
     assert subprocess.call(
-        'cd %s;npm install babel-core babel-cli babel-preset-es2015 babel-polyfill babelify browserify browserify-shim'
-        % repr(DIRNAME),
+        'cd "%s" && npm install babel-core babel-cli babel-preset-es2015 babel-polyfill babelify browserify browserify-shim'
+        % DIRNAME,
         shell=True,
         cwd=DIRNAME) == 0, 'Could not link required node_modules'
     DID_INIT = True
@@ -94,7 +94,7 @@ def _get_and_translate_npm_module(module_name, include_polyfill=False, update=Fa
             pkg_name += '@' + maybe_version_str
         # make sure the module is installed
         assert subprocess.call(
-            'cd %s;npm install %s' % (repr(DIRNAME), pkg_name),
+            'cd "%s" && npm install %s' % (DIRNAME, pkg_name),
             shell=True,
             cwd=DIRNAME
         ) == 0, 'Could not install the required module: ' + pkg_name


### PR DESCRIPTION
This is an alternative solution for PR #274 aka 'AssertionError: Could not link required node_modules' under Windows.
Fixes #125

This fixes two compatibility issues while touching as little as possible.

One is the ";" operator that does not exist in Windows. I chose "&&" to replace it since it functions the same on both systems. This has the side effect of not running the next command if the previous failed, but it looks like this behavior is fine.

The second is the use of repr on paths. This results in the Windows path separator being escaped, which is not accepted by the Windows shell. My solution was to remove the repr and place the string between double quotes to achieve the same effect, but gain compatibility.