### PR TITLE
fix: SyntaxWarning: "is" with a literal

### DIFF
--- a/js2py/internals/opcodes.py
+++ b/js2py/internals/opcodes.py
@@ -798,7 +798,7 @@ OP_CODES = {}
 g = ''
 for g in globals():
     try:
-        if not issubclass(globals()[g], OP_CODE) or g is 'OP_CODE':
+        if not issubclass(globals()[g], OP_CODE) or g == 'OP_CODE':
             continue
     except:
         continue


### PR DESCRIPTION
fix #255

build warning is

```
/build/Js2Py-0.71/js2py/internals/opcodes.py:801: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if not issubclass(globals()[g], OP_CODE) or g is 'OP_CODE':
```
