### PR TITLE
feat: do not use wrapper for python function executions and properly output console

### DIFF
--- a/js2py/base.py
+++ b/js2py/base.py
@@ -973,6 +973,14 @@ class PyJs(object):
             return '{%s}' % ', '.join(res)
         elif self.Class == 'String':
             return str_repr(self.value)
+        elif self.Class == 'Number':
+            return self.to_string().value
+        elif self.Class == 'Boolean':
+            return self.to_string().value
+        elif self.Class == 'Null':
+            return 'null'
+        elif self.Class == 'Undefined':
+            return 'undefined'
         elif self.Class in [
                 'Array', 'Int8Array', 'Uint8Array', 'Uint8ClampedArray',
                 'Int16Array', 'Uint16Array', 'Int32Array', 'Uint32Array',


### PR DESCRIPTION
When we are executing a python function, it does not make sense to wrap the arguments in the JsObjectWrapper, we should instead force cast them to a list or a dict.

Currently, numbers, booleans, null and undefined are wrapped in an incorrect string when output (console.log).