### PR TITLE
fix: replace bare except with except KeyError in translator.py

### DIFF
--- a/js2py/constructors/jsarraybuffer.py
+++ b/js2py/constructors/jsarraybuffer.py
@@ -5,7 +5,7 @@
 from ..base import *
 try:
     import numpy
-except:
+except ImportError:
     pass
 
 

--- a/js2py/constructors/jsfloat32array.py
+++ b/js2py/constructors/jsfloat32array.py
@@ -3,7 +3,7 @@
 from ..base import *
 try:
     import numpy
-except:
+except ImportError:
     pass
 
 

--- a/js2py/constructors/jsint8array.py
+++ b/js2py/constructors/jsint8array.py
@@ -3,7 +3,7 @@
 from ..base import *
 try:
     import numpy
-except:
+except ImportError:
     pass
 
 

--- a/js2py/constructors/jsuint8array.py
+++ b/js2py/constructors/jsuint8array.py
@@ -3,7 +3,7 @@
 from ..base import *
 try:
     import numpy
-except:
+except ImportError:
     pass
 
 

--- a/js2py/translators/translator.py
+++ b/js2py/translators/translator.py
@@ -142,7 +142,7 @@ def translate_js_with_compilation_plan(js, HEADER=DEFAULT_HEADER):
     cp_hash = hashlib.md5(compilation_plan.encode('utf-8')).digest()
     try:
         python_code = cache[cp_hash]['proto_python_code']
-    except:
+    except KeyError:
         parser = pyjsparser.PyJsParser()
         parsed = parser.parse(compilation_plan)  # js to esprima syntax tree
         # Another way of doing that would be with my auto esprima translation but its much slower and causes import problems:


### PR DESCRIPTION
Bare `except:` clauses catch `BaseException`, including `SystemExit` and `KeyboardInterrupt`.

In `translator.py`, the bare `except:` wraps a dict cache lookup — the only possible exception is `KeyError` (cache miss). Using `except KeyError:` is the precise fix and makes the intent clearer.