### PR TITLE
fix: replace 4 bare except clauses with except Exception in jsdate.py

### DIFF
--- a/js2py/constructors/jsdate.py
+++ b/js2py/constructors/jsdate.py
@@ -87,13 +87,13 @@ class PyJsDate(PyJs):
             return 'Invalid Date'
         try:
             dt = self.to_local_dt()
-        except:
+        except Exception:
             raise MakeError(
                 'TypeError',
                 'unsupported date range. Will fix in future versions')
         try:
             return dt.strftime(pattern)
-        except:
+        except Exception:
             raise MakeError(
                 'TypeError',
                 'Could not generate date string from this date (limitations of python.datetime)'
@@ -104,13 +104,13 @@ class PyJsDate(PyJs):
             return 'Invalid Date'
         try:
             dt = self.to_utc_dt()
-        except:
+        except Exception:
             raise MakeError(
                 'TypeError',
                 'unsupported date range. Will fix in future versions')
         try:
             return dt.strftime(pattern)
-        except:
+        except Exception:
             raise MakeError(
                 'TypeError',
                 'Could not generate date string from this date (limitations of python.datetime)'


### PR DESCRIPTION
Bare `except:` clauses catch `BaseException`, including `SystemExit` and `KeyboardInterrupt`.

In `jsdate.py`, 4 bare `except:` clauses wrap datetime conversion and formatting calls:

- `to_local_dt()` and `to_utc_dt()` can raise `OverflowError` (out-of-range dates), `OSError` (pre-1970 dates on Windows), or `ValueError`
- `dt.strftime(pattern)` can raise `ValueError` for unsupported patterns or `UnicodeEncodeError`

All four convert any exception into a JavaScript-style `MakeError('TypeError', ...)`. Using `except Exception:` correctly covers all these cases while still allowing `KeyboardInterrupt` and `SystemExit` to propagate.